### PR TITLE
Patch Slack Using Powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ To disable all functionality, first you should go and disable all the plugins by
 
 Also the plugin files are all stored as a symlinked directory at "${HOME}/.slack" for Linux/Mac, or "%APPLOCALDATA%\.slack" for Windows.  If you delete the symlinked directory the plugins won't load.
 
-I don't have a "uninstallation" instructions to unpatch the ssb-interop.js and index.js files.
+To remove changes in patched files, simply run Update.exe in the appdata folder, typically contained in `%APPLOCALDATA%\slack\Update.exe` as this will reset the files. 
 
 Treat this as a last resort though, since plugins as a whole, or individual plugins, can be disabled in the Slack settings UI (Ctrl+,).
 
-Also The patched ssb-interop.js and index.js files only have a small number of lines appended to the end of them.  If you want you can manually edit these files to remove the ending sections.  Look for the `/** Start Slack Plugins Section **/` line.
+To manually remove the edits, review the patched ssb-interop.js and index.js. These files only have a small number of lines appended to the end of them.  If you want you can manually edit these files to remove the ending sections.  Look for the `/** Start Slack Plugins Section **/` line.
 
 
 ## How to run slack in devtools mode

--- a/patch-slack.bat
+++ b/patch-slack.bat
@@ -1,45 +1,18 @@
+@setlocal enableextensions enabledelayedexpansion
 @echo off
+ECHO      ..::''''::..
+ECHO    .;''        ``;.
+ECHO   ::    ::  ::    ::
+ECHO  ::     ::  ::     ::
+ECHO  :: .:' ::  :: `:. ::
+ECHO  ::  :          :  ::
+ECHO   :: `:.      .:' ::
+ECHO    `;..``::::''..;'
+ECHO      ``::,,,,::''
 
-setlocal
-
-REM TODO: Figure out a way to find the slack version # in "app-3.3.7" folder.  File parsing is rough in batch files.
-IF "%SLACK_INSTALLATION_PATH%"=="" (
-	SET SLACK_INSTALLATION_PATH=%LOCALAPPDATA%\slack\app-3.3.7\resources
-)
-
-SET SLACK_SSB_FILE=%SLACK_INSTALLATION_PATH%\app.asar.unpacked\src\static\ssb-interop.js
-SET SLACK_INDEX_FILE=%SLACK_INSTALLATION_PATH%\app.asar.unpacked\src\static\index.js
-
-SET SHOULD_PATCH_SSB=true
-
-findstr /m loadSlackPlugins %SLACK_SSB_FILE% 2>nul >nul
-if %errorlevel%==0 (
-	SET SHOULD_PATCH_SSB=false
-	REM TODO: repatch is not supported on windows yet.  Batch is not the best language.
-)
-
-if %SHOULD_PATCH_SSB%==true (
-	echo Patching Slack's ssb-interop.js file at %SLACK_SSB_FILE%
-	type patch-files\ssb-interop-snippet-append.js >> %SLACK_SSB_FILE%
-) else (
-	echo Slack's ssb-interop.js already patched, doing nothing.
-)
-
-SET SHOULD_PATCH_INDEX=true
-
-findstr /m loadSlackPlugins %SLACK_INDEX_FILE% 2>nul >nul
-if %errorlevel%==0 (
-	SET SHOULD_PATCH_INDEX=false
-	REM TODO: repatch is not supported on windows yet.  Batch is not the best language.
-)
-
-if %SHOULD_PATCH_INDEX%==true (
-	echo Patching Slack's index.js file at %SLACK_INDEX_FILE%
-	type patch-files\index-snippet-append.js >> %SLACK_INDEX_FILE%
-) else (
-	echo Slack's index.js already patched, doing nothing.
-)
-
-endlocal
-
-if NOT EXIST %LOCALAPPDATA%\.slack mklink /D %LOCALAPPDATA%\.slack %cd%\.slack
+@ECHO OFF
+echo Running slack-customizations.
+PowerShell.exe -NoProfile -Command "& {Start-Process PowerShell.exe -ArgumentList '-NoProfile -ExecutionPolicy Bypass -NoExit -File ""%~dpn0.ps1""' -Verb RunAs}"
+echo Waiting 5 seconds for script to run
+timeout /t 5 /nobreak
+exit

--- a/patch-slack.ps1
+++ b/patch-slack.ps1
@@ -53,8 +53,8 @@ Get-Process Slack -ErrorAction SilentlyContinue | Stop-Process
 #----------------------------------------------------------------------------#
 #                 Identify Paths Based on Install Locations                  #
 #----------------------------------------------------------------------------#
-$slackBaseDir = "$env:LocalAppData\Slack", "C:\Program Files (x86)\Slack"
-$installations = Get-ChildItem $slackBaseDir  -Filter *.exe -ea SilentlyContinue  | Where-Object { $_.Name.StartsWith("app-") -or $_.Name -match 'slack.exe'} | Select-PSFObject * -ScriptProperty @{
+[string[]]$slackBaseDir = "$env:LocalAppData\Slack", "C:\Program Files (x86)\Slack"
+$installations = Get-ChildItem -Path @($slackBaseDir) -Filter *.exe -ea SilentlyContinue -Recurse | Where-Object { $_.Name.StartsWith("app-") -or $_.Name -match 'slack.exe' } | Select-PSFObject * -ScriptProperty @{
     Version = {
         try
         {
@@ -82,7 +82,7 @@ Write-PSFMessage -Level Important -Message "Choosing highest present Slack versi
 #----------------------------------------------------------------------------#
 #                            PATCH index.js                                  #
 #----------------------------------------------------------------------------#
-$filename = (Get-ChildItem -Path $installations.Directory -Recurse | Where-Object {$_.FullName -match 'resources\\app.asar.unpacked\\src\\static\\index\.js' -and $_.FullName -match [string]$Version}).FullName
+$filename = (Get-ChildItem -Path $installations.Directory -Recurse | Where-Object { $_.FullName -match 'resources\\app.asar.unpacked\\src\\static\\index\.js' -and $_.FullName -match [string]$Version }).FullName
 $content = Get-Content $filename -Raw
 $modAdded = $false;
 $MatchPlugins = '(?ms)(\/\*\*\sStart\sSlack\sPlugins\sSection\s\*\*\/.*\/\*\*\sEnd\sSlack\sPlugins\sSection\s\*\*\/)'
@@ -120,7 +120,7 @@ else
 #----------------------------------------------------------------------------#
 #                               PATCH ssb-interop.js                         #
 #----------------------------------------------------------------------------#
-$filename = (Get-ChildItem -Path $installations.Directory -Recurse | Where-Object {$_.FullName -match "resources\\app.asar.unpacked\\src\\static\\ssb\-interop\.js" -and $_.FullName -match [string]$Version}).FullName
+$filename = (Get-ChildItem -Path $installations.Directory -Recurse | Where-Object { $_.FullName -match "resources\\app.asar.unpacked\\src\\static\\ssb\-interop\.js" -and $_.FullName -match [string]$Version }).FullName
 $content = Get-Content $filename -Raw
 
 #----------------------------------------------------------------------------#

--- a/patch-slack.ps1
+++ b/patch-slack.ps1
@@ -1,0 +1,160 @@
+<#
+
+If any windows users like myself hate having to manually update this whenever a new Slack version is released. Here is a powershell script I found in another repository (credit to the original author) and edited to support being able to run on startup and append if required.
+# SOURCE: Andrew Cartwright saved me a ton of time...
+# Original Post: https://github.com/laCour/slack-night-mode/issues/73#issuecomment-385613286
+Instructions:
+Search for Powershell in windows search
+Open "Windows Powershell ISE"
+Copy below script into Windows Powershell ISE
+Hit save, give it any name, keep the file type as "PowerShell Files" and remember the location you saved it at. (This means you can just run that file in future from now on)
+Press F5 on the keyboard to execute the script
+Close Windows Powershell ISE
+
+changes
+2018-05-01 // Andrew Cartwright // original authoring
+2018-10-10 // SheldonH          // Updated invoking of slack after startup.
+2019-03-04 // Sheldon           // Updated to handle app installed to program x86 and remove the custom content with new
+2019-03-07 // SheldonH          // signficant changes to handle usage with slack-customizations, patching, symlink and copying contents from repo into local folder. This eliminates remote calls
+
+#>
+$script:RepoDirectory = $PSScriptRoot
+
+# used for better logging and output
+if ((Get-Module PSFramework -ListAvailable | Select-Object -First 1).Count -eq 0)
+{
+    Write-Verbose "preimport.ps1 > installing PSFramework as not showing currently available to current user"
+    Install-Module PSFramework -Scope CurrentUser -Force -AllowClobber -Confirm:$false
+}
+
+
+$PatchFiles = [pscustomobject]@{
+    'ssb-interop-snippet-append.js' = (Get-Content -Path (Join-Path $script:RepoDirectory 'patch-files\ssb-interop-snippet-append.js') -Raw)
+    'index-snippet-append.js'       = (Get-Content -Path (Join-Path $script:RepoDirectory 'patch-files\index-snippet-append.js') -Raw)
+}
+
+#----------------------------------------------------------------------------#
+#                               Local Storage                                #
+#----------------------------------------------------------------------------#
+
+$PluginDirectory = (New-Item -Path (Join-Path $env:UserProfile '.slack') -ItemType Directory -Force).FullName
+$SymLinkLocation = (    New-Item -Path $SymLinkLocation -ItemType SymbolicLink -Value $PluginDirectory -Force).FullName
+Start-Process -FilePath 'CMD.EXE' -ArgumentList ('/C robocopy.exe "{0}" "{1} " /NFL /NC  /XD "*tests"' -f "$script:RepoDirectory\.slack ", $PluginDirectory) -NoNewWindow -PassThru | Wait-Process
+
+
+#----------------------------------------------------------------------------#
+#                                 Stop Slack                                 #
+#----------------------------------------------------------------------------#
+Get-Process Slack -ErrorAction SilentlyContinue | Stop-Process
+
+
+
+#----------------------------------------------------------------------------#
+#                 Identify Paths Based on Install Locations                  #
+#----------------------------------------------------------------------------#
+$slackBaseDir = "$env:LocalAppData\Slack", "C:\Program Files (x86)\Slack"
+$installations = Get-ChildItem $slackBaseDir  -Filter *.exe -ea SilentlyContinue  | Where-Object { $_.Name.StartsWith("app-") -or $_.Name -match 'slack.exe'} | Select-PSFObject * -ScriptProperty @{
+    Version = {
+        try
+        {
+            [version]$this.Name.Substring(4)
+            Write-PSFMessage -Level Important -Function 'patch-slack.ps1' -message "Matched Version from [version]`$this.Name.Substring(4): $([version]$this.Name.Substring(4))"
+
+        }
+        catch
+        {
+
+            $this.VersionInfo.ProductVersion
+            Write-PSFMessage -Level Important -Function 'patch-slack.ps1' -message "Matched Version from `$this.VersionInfo.ProductVersion: $($this.VersionInfo.ProductVersion)"
+        }
+
+    }
+} | Sort-Object -Property Version | Select-Object -Last 1
+$Version = $installations.Version # to ensure if windows 10 + app, etc installed, this is updating the most recent version installed
+Write-PSFMessage -Level Important -Message "Choosing highest present Slack version: $version";
+
+
+
+
+#----------------------------------------------------------------------------#
+#                            PATCH index.js                                  #
+#----------------------------------------------------------------------------#
+$filename = (Get-ChildItem -Path $installations.Directory -Recurse | Where-Object FullName -match 'resources\\app.asar.unpacked\\src\\static\\index\.js').FullName
+$content = Get-Content $filename -Raw
+$modAdded = $false;
+$MatchPlugins = '(?ms)(\/\*\*\sStart\sSlack\sPlugins\sSection\s\*\*\/.*\/\*\*\sEnd\sSlack\sPlugins\sSection\s\*\*\/)'
+#----------------------------------------------------------------------------#
+#                      Clear Custom Content & Add Back                       #
+#----------------------------------------------------------------------------#
+if ($content -match $MatchPlugins)
+{
+    Write-PSFMessage -Level Important -Message "Clearing the custom content"
+
+    # replace for each match identified. Simple loop to do this. Found inspiration on this from technet here -- http://bit.ly/2Uxspyk
+    ([Regex]::Matches($content, $MatchPlugins)).Groups.Name | ForEach-Object {
+        $content = $content -replace $MatchPlugins, ''
+    }
+    Set-Content  -Path $FileName -Value  $content  -Force
+}
+#----------------------------------------------------------------------------#
+#                            add custom injection                            #
+#----------------------------------------------------------------------------#
+if ($content -notmatch '\/\/ CUSTOM START')
+{
+    Add-Content -Path $filename -Value $PatchFiles.'index-snippet-append.js'
+    Write-PSFMessage -Level Important -Message "Mod Added To index.js";
+    $modAdded = $true;
+}
+else
+{
+    Write-PSFMessage -Level Important -Message "Mod Detected In index.js - Skipping";
+    Write-PSFMessage -Level Warning "To remove theme edit this file: $($version.FullName)\resources\app.asar.unpacked\src\static\index.js"
+}
+
+
+
+
+#----------------------------------------------------------------------------#
+#                               PATCH ssb-interop.js                         #
+#----------------------------------------------------------------------------#
+$filename = (Get-ChildItem -Path $installations.Directory -Recurse | Where-Object FullName -match "resources\\app.asar.unpacked\\src\\static\\ssb\-interop\.js").FullName
+$content = Get-Content $filename -Raw
+
+#----------------------------------------------------------------------------#
+#                      Clear Custom Content & Add Back                       #
+#----------------------------------------------------------------------------#
+if ($content -match $MatchPlugins)
+{
+    Write-PSFMessage -Level Important -Message "Clearing the custom content"
+    # replace for each match identified. Simple loop to do this. Found inspiration on this from technet here -- http://bit.ly/2Uxspyk
+    ([Regex]::Matches($content, $MatchPlugins)).Groups.Name | ForEach-Object {
+        $content = $content -replace $MatchPlugins, ''
+    }
+    Set-Content  -Path $FileName -Value  $content  -Force
+}
+
+#----------------------------------------------------------------------------#
+#                            add custom injection                            #
+#----------------------------------------------------------------------------#
+if ($content -notmatch $MatchPlugins)
+{
+    Add-Content -Path $filename -Value $PatchFiles.'ssb-interop-snippet-append.js'
+    Write-PSFMessage -Level Important -Message "Mod Added To ssb-interop.js";
+    $modAdded = $true;
+}
+else
+{
+    Write-PSFMessage -Level Important -Message "Mod Detected In ssb-interop.js - Skipping";
+    Write-PSFMessage -Level Warning "To remove theme edit this file: $($version.FullName)\resources\app.asar.unpacked\src\static\ssb-interop.js"
+}
+
+if (@(Get-Process "slack" -ErrorAction SilentlyContinue).Count -gt 0)
+{
+    Write-PSFMessage -Level Important -Message "Mod Complete - Mod Will Take Effect After Slack Is Restarted";
+    Get-Process Slack -ErrorAction SilentlyContinue | Stop-Process
+}
+else
+{
+    Write-PSFMessage -Level Important -Message "Mod Complete";
+}
+Start-Process $Installations.FullName -NoNewWindow

--- a/patch-slack.ps1
+++ b/patch-slack.ps1
@@ -38,13 +38,14 @@ $PatchFiles = [pscustomobject]@{
 #----------------------------------------------------------------------------#
 
 $PluginDirectory = (New-Item -Path (Join-Path $env:UserProfile '.slack') -ItemType Directory -Force).FullName
-$SymLinkLocation = (    New-Item -Path $SymLinkLocation -ItemType SymbolicLink -Value $PluginDirectory -Force).FullName
+New-Item -Path (Join-Path $env:LocalAppData '.slack') -ItemType SymbolicLink -Value $PluginDirectory -Force
 Start-Process -FilePath 'CMD.EXE' -ArgumentList ('/C robocopy.exe "{0}" "{1} " /NFL /NC  /XD "*tests"' -f "$script:RepoDirectory\.slack ", $PluginDirectory) -NoNewWindow -PassThru | Wait-Process
 
 
 #----------------------------------------------------------------------------#
 #                                 Stop Slack                                 #
 #----------------------------------------------------------------------------#
+Write-PSFMessage -Level Important -Message "Stopping slack";
 Get-Process Slack -ErrorAction SilentlyContinue | Stop-Process
 
 
@@ -157,4 +158,5 @@ else
 {
     Write-PSFMessage -Level Important -Message "Mod Complete";
 }
+Write-PSFMessage -Level Important -Message "Starting $($Installations.FullName)";
 Start-Process $Installations.FullName -NoNewWindow


### PR DESCRIPTION
# If applied, this commit will...
Change patching behavior to use powershell instead of batch file. 

# Why is this change needed?
Prior to this change, bat file was used which was unable to do more advanced path detection, handle symlinking properly, and handle removal of the patching contents.

# How does it address the issue?
This change will 
- dynamically pick up install path.
- clear customization and repatch
- copy contents from repo directory into local user directory
- log messages using PSFramework
- remove customizations can be easily add later using the same logic if required

Tested rerunning several times and it avoided duplicating plugin injection.
